### PR TITLE
Connect DTR to Prior Auth service on submit.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,9 @@ class App extends Component {
     super(props);
     this.state = {
       questionnaire: null,
-      cqlPrepoulationResults: null
+      cqlPrepoulationResults: null,
+      deviceRequest: null,
+      bundle: null
     }
     this.smart = props.smart;
   }
@@ -22,6 +24,7 @@ class App extends Component {
     .then(artifacts => {
       console.log("fetched needed artifacts:", artifacts)
       this.setState({questionnaire: artifacts.questionnaire})
+      this.setState({deviceRequest: artifacts.deviceRequest})
       const executionInputs = {
         elm: artifacts.mainLibraryElm,
         elmDependencies: artifacts.dependentElms,
@@ -32,15 +35,16 @@ class App extends Component {
     })
     .then(cqlResults => {
       console.log("executed cql, result:", cqlResults);
-      this.setState({cqlPrepoulationResults: cqlResults})
+      this.setState({bundle: cqlResults.bundle})
+      this.setState({cqlPrepoulationResults: cqlResults.elmResults})
     });
   }
 
   render() {
-    if (this.state.questionnaire && this.state.cqlPrepoulationResults){
+    if (this.state.questionnaire && this.state.cqlPrepoulationResults && this.state.bundle){
       return (
         <div className="App">
-          <QuestionnaireForm qform = {this.state.questionnaire} cqlPrepoulationResults= {this.state.cqlPrepoulationResults} />
+          <QuestionnaireForm qform = {this.state.questionnaire} cqlPrepoulationResults= {this.state.cqlPrepoulationResults} deviceRequest = {this.state.deviceRequest} bundle = {this.state.bundle} />
         </div>
       );
     } else {

--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -506,7 +506,7 @@ export default class QuestionnaireForm extends Component {
         priorAuthBundle.entry.unshift({ resource: priorAuthClaim })
 
         const Http = new XMLHttpRequest();
-        const priorAuthUrl = "https://davinci-prior-auth.logicahealth.org/fhir";
+        const priorAuthUrl = "https://davinci-prior-auth.logicahealth.org/fhir/Claim/$submit";
         // const priorAuthUrl = "http://localhost:9000/fhir/Claim/$submit";
         Http.open("POST", priorAuthUrl);
         Http.setRequestHeader("Content-Type", "application/fhir+json");

--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -444,9 +444,7 @@ export default class QuestionnaireForm extends Component {
                         }
                 }
                 // FHIR fields are not allowed to be empty or null, so we must prune
-                if ((answerItem.answer.length < 1) ||
-                    (JSON.stringify(answerItem.answer[0]) == "{}") ||
-                    (answerItem.answer[0].hasOwnProperty("valueString") && answerItem.answer[0].valueString == null))
+                if (this.isEmptyAnswer(answerItem.answer))
                 {
                     // console.log("Removing empty answer: ", answerItem);
                     delete answerItem.answer;
@@ -526,6 +524,16 @@ export default class QuestionnaireForm extends Component {
                 console.log(this.responseText);
             }
         }
+    }
+
+    isEmptyAnswer(answer) {
+        return ((answer.length < 1) ||
+                (JSON.stringify(answer[0]) == "{}") ||
+                (answer[0].hasOwnProperty("valueString") && (answer[0].valueString == null || answer[0].valueString == "")) ||
+                (answer[0].hasOwnProperty("valueDateTime") && (answer[0].valueDateTime == null || answer[0].valueDateTime == "")) ||
+                (answer[0].hasOwnProperty("valueDate") && (answer[0].valueDate == null || answer[0].valueDate == "")) ||
+                (answer[0].hasOwnProperty("valueBoolean") && (answer[0].valueBoolean == null || answer[0].valueBoolean == "")) ||
+                (answer[0].hasOwnProperty("valueQuantity") && (answer[0].valueQuantity.value == null || answer[0].valueQuantity.value == "")));
     }
 
     makeReference(bundle, resourceType) {

--- a/src/elmExecutor/buildPopulatedResourceBundle.js
+++ b/src/elmExecutor/buildPopulatedResourceBundle.js
@@ -99,6 +99,7 @@ function buildPopulatedResourceBundle(smart, neededResources) {
         readResources(neededResources.slice(), () => {
           const bundle = {
             resourceType: "Bundle",
+            type: "collection",
             entry: entryResources.map(r => ({ resource: r }))
           };
           resolve(bundle);

--- a/src/elmExecutor/executeElm.js
+++ b/src/elmExecutor/executeElm.js
@@ -12,8 +12,13 @@ function executeElm(smart, fhirVersion, executionInputs) {
     buildPopulatedResourceBundle(smart, neededResources)
     .then(function(resourceBundle) {
       console.log("Fetched resources are in this bundle:", resourceBundle);
+      console.log(JSON.stringify(resourceBundle));
       patientSource.loadBundles([resourceBundle]);
-      const results = executeElmAgainstPatientSource(executionInputs, patientSource);
+      const elmResults = executeElmAgainstPatientSource(executionInputs, patientSource);
+      const results = {
+        bundle: resourceBundle,
+        elmResults: elmResults
+      }
       resolve(results);
     })
     .catch(function(err){reject(err)});


### PR DESCRIPTION
## Summary
This pull request connects DTR to the Prior-Auth web service.

See https://github.com/HL7-DaVinci/prior-auth for details on the prior-auth service.

## Hard-coded Service
Currently the prior-authorization service is hard-coded to use the Da Vinci HSPC instance running at `https://davinci-prior-auth.logicahealth.org/fhir`.

You can manually change this endpoint in `QuestionnaireForm.jsx` line 509-510:
```javascript
        const priorAuthUrl = "https://davinci-prior-auth.logicahealth.org/fhir/Claim/$submit";
        // const priorAuthUrl = "http://localhost:9000/fhir/Claim/$submit";
```

In the future (post Connectathon?) we can make this a parameter that is passed into `launch` or another configurable approach.

## What This Does
- After the Questionnaire Form is populated, the user clicks Submit.
- A FHIR `Bundle` is generated that contains:
  1. A prior-authorization `Claim`
  2. A `QuestionnaireResponse` generated from the form
  3. All the resources used in the CQL calculation to populate the form
- The `Bundle` is `POST`ed to a Prior Authorization `Claim/$submit` operation endpoint.
- The result is logged into the `console` and `alert`ed.