### PR TITLE
Fix spelling error in prior auth Claim.

### DIFF
--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -472,7 +472,7 @@ export default class QuestionnaireForm extends Component {
             created: authored,
             provider: { reference: this.makeReference(priorAuthBundle, "Practitioner") },
             priority: {coding: [{"code": "normal"}]},
-            presciption: { reference: this.makeReference(priorAuthBundle, "DeviceRequest") },
+            prescription: { reference: this.makeReference(priorAuthBundle, "DeviceRequest") },
             supportingInfo: [{
                 sequence: 1,
                 category: {coding: [{


### PR DESCRIPTION
Fixes a spelling error in the prior auth Claim: `Claim.prescription` was missing the second `r`.