### PR TITLE
[292] add client id registration

### DIFF
--- a/public/register.html
+++ b/public/register.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+</head>
+
+<body>
+    <div id="reg"></div>
+    <script src="./register.bundle.js"></script>
+</body>
+
+</html>

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Install [node.js](https://nodejs.org/en/).
 3. Run `npm install`
 4. Run `npm start`
 
-The service will run on port 3005. This can be changed in `package.json` and `webpack.dev.config.js`.
+The service will run on port 3005. This can be changed in `package.json` and `webpack.dev.config.js`.  Note that the project uses `https` by default.  This can also be changed in `webpack.dev.config.js` by changing the `https` boolean.  There is currently no redirection between `https` and `http`, so using the wrong scheme in the url will result in an empty response.
 
 ## Using the App
 

--- a/src/RegisterPage.css
+++ b/src/RegisterPage.css
@@ -20,3 +20,40 @@
     background-color:#DDD;
     border:2px solid #EEE;
 }
+
+.left{
+    width:30%;
+    float:left;
+    display:block;
+    height:100%;
+}
+
+.sep{
+    width:60%;
+    float:left;
+    display:block;
+    height:100%;
+    margin-left: 15px;
+}
+
+.bold{
+    font-weight: bold;
+}
+
+.delete{
+    border:1px solid black;
+    font-family: monospace;
+    height:10px;
+    width:10px;
+    line-height:8px;
+    text-align:center;
+    margin-right:250px;
+    float:right;
+    background-color:#F33a5b;
+    color:white;
+    cursor:pointer;
+}
+
+.delete:hover{
+    background-color:#Fb5c8f;
+}

--- a/src/RegisterPage.css
+++ b/src/RegisterPage.css
@@ -1,0 +1,22 @@
+.client-id{
+    width: 200px;
+}
+
+.submit-btn{
+    display:block;
+    margin-top:15px;
+    background-color:white;
+    width:50px;
+    height:25px;
+}
+
+.bool-checkbox{
+    display:inline-block;
+    
+}
+
+.client-id:disabled {
+    color:#666;
+    background-color:#DDD;
+    border:2px solid #EEE;
+}

--- a/src/RegisterPage.jsx
+++ b/src/RegisterPage.jsx
@@ -1,0 +1,58 @@
+import React, { Component } from "react";
+import { hot } from "react-hot-loader";
+import "./RegisterPage.css";
+
+class RegisterPage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      clientId: "",
+      fhirUrl: "",
+      toggle: false
+    }
+
+    this.submit = this.submit.bind(this);
+  }
+
+  componentDidMount(){
+  }
+
+
+  submit(){
+    let storedJSON = localStorage.getItem("dtrAppTempClientSet")
+    if(!storedJSON) {
+        storedJSON = {};
+    }else{
+        storedJSON = JSON.parse(storedJSON);
+    }
+
+    if(this.state.toggle) {
+        storedJSON["default"] = this.state.clientId;
+    }else{
+        storedJSON[this.state.fhirUrl] = this.state.clientId;
+    }
+
+    localStorage.setItem("dtrAppTempClientSet", JSON.stringify(storedJSON));
+    console.log(localStorage);
+  }
+
+  render() {
+    return(
+        <div>
+            <p>Client Id</p>
+            <input className="client-id" value={this.state.clientId} onChange={(e)=>{this.setState({clientId:e.target.value})}}></input>
+
+            <p>Fhir Server (iss)</p>
+            <input className="client-id" value={this.state.fhirUrl} onChange={(e)=>{this.setState({fhirUrl:e.target.value})}} disabled = {this.state.toggle}></input>
+
+            <p>Last Accessed Fhir Server:</p>
+            <p>{localStorage.getItem("lastAccessedServiceUri") || "None"}</p>
+            <br></br>
+            <input className="bool-checkbox" type="checkbox" onClick={()=>{this.setState({toggle: !this.state.toggle})}}></input>
+            <span>Default</span>
+            <button className="btn submit-btn" onClick={this.submit} >Submit</button>
+        </div>
+    )
+  }
+}
+export default hot(module)(RegisterPage);

--- a/src/RegisterPage.jsx
+++ b/src/RegisterPage.jsx
@@ -8,13 +8,21 @@ class RegisterPage extends Component {
     this.state = {
       clientId: "",
       fhirUrl: "",
-      toggle: false
+      toggle: false,
+      json: {}
     }
 
     this.submit = this.submit.bind(this);
   }
 
   componentDidMount(){
+    let storedJSON = localStorage.getItem("dtrAppTempClientSet")
+    if(!storedJSON) {
+        storedJSON = {};
+    }else{
+        storedJSON = JSON.parse(storedJSON);
+    }
+    this.setState({"json": storedJSON});
   }
 
 
@@ -32,26 +40,47 @@ class RegisterPage extends Component {
         storedJSON[this.state.fhirUrl] = this.state.clientId;
     }
 
+    this.setState({"json": storedJSON});
     localStorage.setItem("dtrAppTempClientSet", JSON.stringify(storedJSON));
     console.log(localStorage);
+  }
+
+  delete(fhirUrl) {
+        let storedJSON = localStorage.getItem("dtrAppTempClientSet")
+        if(!storedJSON) {
+            storedJSON = {};
+        }else{
+            storedJSON = JSON.parse(storedJSON);
+        }
+        delete storedJSON[fhirUrl];
+        localStorage.setItem("dtrAppTempClientSet", JSON.stringify(storedJSON));
+        this.setState({"json": storedJSON});
   }
 
   render() {
     return(
         <div>
-            <p>Client Id</p>
-            <input className="client-id" value={this.state.clientId} onChange={(e)=>{this.setState({clientId:e.target.value})}}></input>
+            <div className="left">
+                <p>Client Id</p>
+                <input className="client-id" value={this.state.clientId} onChange={(e)=>{this.setState({clientId:e.target.value})}}></input>
 
-            <p>Fhir Server (iss)</p>
-            <input className="client-id" value={this.state.fhirUrl} onChange={(e)=>{this.setState({fhirUrl:e.target.value})}} disabled = {this.state.toggle}></input>
+                <p>Fhir Server (iss)</p>
+                <input className="client-id" value={this.state.fhirUrl} onChange={(e)=>{this.setState({fhirUrl:e.target.value})}} disabled = {this.state.toggle}></input>
 
-            <p>Last Accessed Fhir Server:</p>
-            <p>{localStorage.getItem("lastAccessedServiceUri") || "None"}</p>
-            <br></br>
-            <input className="bool-checkbox" type="checkbox" onClick={()=>{this.setState({toggle: !this.state.toggle})}}></input>
-            <span>Default</span>
-            <button className="btn submit-btn" onClick={this.submit} >Submit</button>
+                <p>Last Accessed Fhir Server:</p>
+                <p>{localStorage.getItem("lastAccessedServiceUri") || "None"}</p>
+                <br></br>
+                <input className="bool-checkbox" type="checkbox" onClick={()=>{this.setState({toggle: !this.state.toggle})}}></input>
+                <span>Use this client ID by default for all FHIR Servers</span>
+                <button className="btn submit-btn" onClick={this.submit} >Submit</button>
+            </div>
+            <div className="sep">
+                <p>Current Client Ids</p>
+                {Object.keys(this.state.json).map((e)=>{return <div><p><span className="bold">{e}</span>: {this.state.json[e]} <span className="delete" onClick={()=>{this.delete(e)}}>x</span></p> </div>})}
+            </div>
         </div>
+
+
     )
   }
 }

--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -121,7 +121,7 @@ export default class QuestionnaireForm extends Component {
             enableCriteria.forEach((rule) => {
                 const question = this.state.values[rule.question]
                 const answer = findValueByPrefix(rule, "answer");
-                if (typeof question === 'object' && typeof answer === 'object') {
+                if (typeof question === 'object' && typeof answer === 'object' && answer!== null && question!==null) {
                     if (rule.answerQuantity) {
                         // at the very least the unit and value need to be the same
                         results.push(this.evaluateOperator(rule.operator, question.value, answer.value.toString())

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ tokenPost.onload = function() {
       const appContext = {
         template: appString.split("&")[0].split("=")[1],
         request: JSON.parse(appString.split("&")[1].split("=")[1].replace(/\\/g,"")),
-        filepath: auth_response.appContext.split("&")[2].split("=")[1]
+        filepath: appString.split("&")[2].split("=")[1]
       }
       
         var smart = FHIR.client({

--- a/src/launch.js
+++ b/src/launch.js
@@ -1,7 +1,7 @@
 import urlUtils from "./util/url";
+let storedJSON = JSON.parse(localStorage.getItem("dtrAppTempClientSet"));
 
-// Change this to the ID of the client that you registered with the SMART on FHIR authorization server.
-var clientId = "app-login"; // local client
+
 // For demonstration purposes, if you registered a confidential client
 // you can enter its secret here. The demo app will pretend it's a confidential
 // app (in reality it cannot be confidential, since it cannot keep secrets in the
@@ -11,6 +11,27 @@ var secret = null; // set me, if confidential
 // These parameters will be received at launch time in the URL
 var serviceUri = urlUtils.getUrlParameter("iss");
 var launchContextId = urlUtils.getUrlParameter("launch");
+
+// Change this to the ID of the client that you registered with the SMART on FHIR authorization server.
+var clientId = "default"; // local client
+
+
+console.log(serviceUri);
+localStorage.setItem("lastAccessedServiceUri", serviceUri);
+if(storedJSON) {
+    if(storedJSON[serviceUri]) {
+        clientId = storedJSON[serviceUri];
+    }else if(storedJSON["default"]){
+        clientId = storedJSON["default"];
+    }else{
+        const errorMsg = "no client id found in local storage, please go to the /register page to register a client id, or verify that the default clientId string in the code is correctly typed.";
+        document.body.innerText = errorMsg;
+        console.log("The app could not find the appropriate client ID");
+    }
+}else{
+    console.log("Unable to access local storage, try visiting /register if you haven't already");
+}
+
 
 // The scopes that the app will request from the authorization server
 // encoded in a space-separated string:

--- a/src/register.js
+++ b/src/register.js
@@ -1,0 +1,5 @@
+
+import React from "react";
+import ReactDOM from "react-dom";
+import RegisterPage from './RegisterPage';
+ReactDOM.render( <RegisterPage/>, document.getElementById("reg") )

--- a/webpack.config.common.js
+++ b/webpack.config.common.js
@@ -3,7 +3,10 @@ const path = require("path");
 module.exports = {
   entry: {
     launch: path.resolve(__dirname, "src/launch.js"),
-    index: path.resolve(__dirname, "src/index.js")
+    index: path.resolve(__dirname, "src/index.js"),
+    register: path.resolve(__dirname, "src/register.js"),
+
+
   },
   output: {
     filename: "[name].bundle.js",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -16,13 +16,14 @@ module.exports = merge(common, {
   devServer: {
     contentBase: path.resolve(__dirname, "public"),
     port: 3005,
-    https: false,
+    https: true,
     public: "0.0.0.0",
     hotOnly: true,
     historyApiFallback: {
         rewrites: [
           { from: /index/, to: '/index.html' },
-          { from: /launch/, to: '/launch.html' }
+          { from: /launch/, to: '/launch.html' },
+          { from: /register/, to: '/register.html'}
         ]
       },
     proxy: [{


### PR DESCRIPTION
Adds a new page to the dtr app, `/register`, which is a simple form that allows the user to specify the client id.  Selecting the default option will use the provided client id for any launch sequence that the app goes through.  Otherwise, client id's can be tied to a fhir server url, so that requests to `localhost:8080', for example, automatically use a different client id than requests on the app orchard or to another fhir server.  

Note that the url provided needs to be exactly the same as the `iss` that is provided during the launch sequence.  If you're not sure what the `iss` is exactly, try to launch the smart app against the server you want to register for, and check the register page, it should show the exact `iss` it received in the last request it made.