### PR TITLE
Update DTR to use the patient identifier instead of patient id

### DIFF
--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -638,7 +638,7 @@ export default class QuestionnaireForm extends Component {
                 var patientEntry = claimResponseBundle.entry.find(function(entry) {
                     return (entry.resource.resourceType == "Patient");
                 });
-                let priorAuthUri = "priorauth?identifier=" + claimResponse.preAuthRef + "&patient.identifier=" + patientEntry.resource.id;
+                let priorAuthUri = "priorauth?identifier=" + claimResponse.preAuthRef + "&patient.identifier=" + patientEntry.resource.identifier[0].value;
                 console.log(priorAuthUri)
                 window.location.href = priorAuthUri;
             }


### PR DESCRIPTION
PriorAuth was updated to use patient identifier instead of patient id. Updating here to use the identifier. 
The PAS IG currently does not say what to do if there is no identifier or if more than one is provided. For the time being DTR supplies one so we will just use the first identifier provided