### PR TITLE
Fix errors

### DIFF
--- a/src/components/QuestionnaireForm/QuestionnaireForm.css
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.css
@@ -47,14 +47,15 @@ html {
 }
 
 .submit-button-panel {
-  margin-left: 55px;
+  float:right;
+  margin-right: 10px;
 }
 
 .submit-button {
   margin-left: 5px;
-  border-width: 1px 1px 1px 5px;
+  border-width: 1px;
   border-style:solid;
-  border-color:#333;
+  border-color:#ced5d9;
 }
 
 .submit-button:hover {

--- a/src/components/UserMessage/UserMessage.css
+++ b/src/components/UserMessage/UserMessage.css
@@ -1,6 +1,8 @@
 .usermessage {
     margin: 0 10em 2em 2em;
     padding: 1em 1em 1em 1.5em;
+    transition: none;
+    opacity: 1;
 }
 
 .usermessage .details {

--- a/src/elmExecutor/buildPopulatedResourceBundle.js
+++ b/src/elmExecutor/buildPopulatedResourceBundle.js
@@ -1,4 +1,4 @@
-import 'url-search-params-polyfill';
+import "url-search-params-polyfill";
 function doSearch(smart, type, fhirVersion, request, callback) {
   const q = {};
   let usePatient = true;
@@ -161,8 +161,15 @@ function buildPopulatedResourceBundle(
                 entryResources.push(...results);
               }
               if (error) {
-                console.error(error);
-                consoleLog(error.statusText, "errorClass");
+                const resourceError = new Error(error);
+                if(resourceError.message.includes("OperationOutcome")) {
+                    let splitError = resourceError.message.split("{");
+                    splitError[0] = "";
+                    splitError = splitError.join("{");
+                    consoleLog("Error fetching resource", "errorClass", JSON.parse(splitError));
+                }else{
+                    consoleLog("Error fetching resource", "errorClass", resourceError.message);
+                }
               }
               readResources(neededResources, callback);
             });
@@ -179,7 +186,7 @@ function buildPopulatedResourceBundle(
         });
       },
       error => {
-        consoleLog("error: " + error, "errorClass");
+        consoleLog("error: " + error, "errorClass", `failed to fetch patient ${smart.patient.id}`);
         console.log(error);
         reject(error);
       }


### PR DESCRIPTION
The errors from the SMART client are returned as a string, which makes it difficult to parse out the useful information.  Normally we'd just want the OperationOutcome by itself as JSON but it gets mixed in with other info like the URL and status code.  This is what the manipulation of the error string is doing, pulling out the OperationOutcome.   In the app orchard, the warning now looks like this:

![image](https://user-images.githubusercontent.com/24882348/77583220-134b6480-6eb7-11ea-941c-376d65a020ff.png)
