### PR TITLE
659 - Support Canonical URLs for ValueSets used by CQL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,10 @@ To run configurable template:
 
 The configurable template will use the environment variables passed to the docker run command to replace the `PROXY_TARGET`, `SERVER_PORT`, and `SERVER_HTTPS` values in the webpack configuration file.
 
+# Other Documentation
+
+[Using ValueSets in DTR Rules](./using-valuesets-in-rules.md)
+
 # License
 
 This project is licensed under the Apache License 2.0. See [LICENSE](/LICENSE) for more details.

--- a/src/App.js
+++ b/src/App.js
@@ -199,15 +199,15 @@ class App extends Component {
       elm.library.valueSets.def.forEach(valueSetDef => {
         // find FHIR value set artifact
         let valueSet = artifacts.valueSets.find(
-          valueSet => valueSet.id == valueSetDef.id
+          valueSet => valueSet.id == valueSetDef.id || valueSet.url == valueSetDef.id
         );
         if (valueSet != null) {
           // make sure it has an expansion
           if (valueSet.expansion != null) {
             // add all codes to the the value set db. it is a map in a map, where the first layer key
             // is the value set id and second layer key is the value set version. for this purpose we are using un-versioned valuesets
-            executionInputs.valueSetDB[valueSet.id] = {};
-            executionInputs.valueSetDB[valueSet.id][
+            executionInputs.valueSetDB[valueSetDef.id] = {};
+            executionInputs.valueSetDB[valueSetDef.id][
               ""
             ] = valueSet.expansion.contains.map(code => {
               return {

--- a/src/util/fetchArtifacts.js
+++ b/src/util/fetchArtifacts.js
@@ -96,9 +96,8 @@ function fetchArtifacts(fhirPrefix, filePrefix, questionnaireReference, fhirVers
       const dataRequirementsWithValuesets = libraryResource.dataRequirement.filter(dr => dr.codeFilter != null && dr.codeFilter[0].valueSet != null);
       const valueSetUrls = dataRequirementsWithValuesets.map(dr => dr.codeFilter[0].valueSet);
       valueSetUrls.forEach(valueSetUrl => {
-        // assume that the valueSets are full URLs
-        //TODO: handle valuesets that are URN OIDs pointing to a ValueSet repository
-        fetchValueSet(valueSetUrl);
+        // assume that the valueSets are canonical URLs that we need to ask the fhir server for an expansion
+        fetchValueSet(buildFhirUrl("ValueSet/$expand?url=" + valueSetUrl));
       });
     }
 

--- a/using-valuesets-in-rules.md
+++ b/using-valuesets-in-rules.md
@@ -1,0 +1,62 @@
+# Using ValueSets in DTR Rules
+
+ValueSets can be used by the CQL prepopulation logic. These ValueSets can come from the ruleset's resource or from VSAC.
+
+## Using a ValueSet in CQL
+
+To use a ValueSet in CQL you have to reference it in two places. The CQL logic, and the FHIR Library resource. 
+
+### CQL Logic
+
+The `valueset` statements should be placed at the top of the CQL file after the `library`, `using`, and `include` statements and before any `define` statements. For example, defining the use of VSAC ValueSet "Bronchiectasis" with oid "2.16.840.1.113762.1.4.1219.3" and "COPD" with oid "2.16.840.1.113762.1.4.1219.6":
+
+```
+valueset "COPD": '2.16.840.1.113762.1.4.1219.6'
+valueset "Bronchiectasis": '2.16.840.1.113762.1.4.1219.3'
+```
+
+In this example `"Bronchiectasis"` and `"COPD"` are what will be used to reference the ValueSets in this CQL library file. `'2.16.840.1.113762.1.4.1219.3'` and `'2.16.840.1.113762.1.4.1219.6'` are the external identifiers for the ValueSets.
+
+ValueSets can be used in CQL in a few different ways. But they are most commonly used to filter a retrieval of data. For example, this statement returns all Bronchiectasis Conditons:
+
+```
+define "Bronchiectasis Conditions":
+  [Condition: "Bronchiectasis"]
+```
+
+### FHIR Library
+
+For ValueSets to be properly used by CQL in the context of FHIR, the corresponding FHIR Library resource must have a [dataRequirement](http://hl7.org/fhir/library-definitions.html#Library.dataRequirement) element for each ValueSet used. For the above CQL example, the Library must reference the ValueSets like so:
+
+```json
+{
+  "resourceType": "Library",
+  ...
+  "dataRequirement": [
+    {
+      "type": "Condition",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "<server-path>ValueSet/2.16.840.1.113762.1.4.1219.6"
+        }
+      ]
+    },
+    {
+      "type": "Condition",
+      "codeFilter": [
+        {
+          "path": "code",
+          "valueSet": "<server-path>ValueSet/2.16.840.1.113762.1.4.1219.3"
+        }
+      ]
+    }
+  ],
+  ...
+}
+```
+
+NOTE: CRD will replace `<server-path>` with the base path of the CRD FHIR endpoint.
+
+The resource type that each ValueSet will be used to filter on is referenced here. This should be used to indicate to the SMART applications or the FHIR server the scope of which resources are required for execution.
+

--- a/using-valuesets-in-rules.md
+++ b/using-valuesets-in-rules.md
@@ -1,21 +1,21 @@
 # Using ValueSets in DTR Rules
 
-ValueSets can be used by the CQL prepopulation logic. These ValueSets can come from the ruleset's resource or from VSAC.
+ValueSets can be used by the CQL prepopulation logic. These ValueSets can come from the ruleset's local resources or from VSAC.
 
 ## Using a ValueSet in CQL
 
-To use a ValueSet in CQL you have to reference it in two places. The CQL logic, and the FHIR Library resource. 
+To use a ValueSet in CQL you have to reference it in two places. The CQL logic, and the FHIR Library resource. VSAC ValueSets should be referenced by the canonical URL for VSAC, `http://cts.nlm.nih.gov/fhir/ValueSet/{OID}`.
 
 ### CQL Logic
 
-The `valueset` statements should be placed at the top of the CQL file after the `library`, `using`, and `include` statements and before any `define` statements. For example, defining the use of VSAC ValueSet "Bronchiectasis" with oid "2.16.840.1.113762.1.4.1219.3" and "COPD" with oid "2.16.840.1.113762.1.4.1219.6":
+The `valueset` statements should be placed at the top of the CQL file after the `library`, `using`, and `include` statements and before any `define` statements. For example, defining the use of VSAC ValueSet "Bronchiectasis" with oid "2.16.840.1.113762.1.4.1219.3" and "COPD" with id "copd" from local ruleset resources:
 
 ```
-valueset "COPD": '2.16.840.1.113762.1.4.1219.6'
-valueset "Bronchiectasis": '2.16.840.1.113762.1.4.1219.3'
+valueset "COPD": 'copd'
+valueset "Bronchiectasis": 'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.3'
 ```
 
-In this example `"Bronchiectasis"` and `"COPD"` are what will be used to reference the ValueSets in this CQL library file. `'2.16.840.1.113762.1.4.1219.3'` and `'2.16.840.1.113762.1.4.1219.6'` are the external identifiers for the ValueSets.
+In this example `"Bronchiectasis"` and `"COPD"` are what will be used to reference the ValueSets in this CQL library file. `'http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.3'` and `'cpod'` are the external identifiers for the ValueSets.
 
 ValueSets can be used in CQL in a few different ways. But they are most commonly used to filter a retrieval of data. For example, this statement returns all Bronchiectasis Conditons:
 
@@ -38,7 +38,7 @@ For ValueSets to be properly used by CQL in the context of FHIR, the correspondi
       "codeFilter": [
         {
           "path": "code",
-          "valueSet": "<server-path>ValueSet/2.16.840.1.113762.1.4.1219.6"
+          "valueSet": "<server-path>ValueSet/copd"
         }
       ]
     },
@@ -47,7 +47,7 @@ For ValueSets to be properly used by CQL in the context of FHIR, the correspondi
       "codeFilter": [
         {
           "path": "code",
-          "valueSet": "<server-path>ValueSet/2.16.840.1.113762.1.4.1219.3"
+          "valueSet": "http://cts.nlm.nih.gov/fhir/ValueSet/2.16.840.1.113762.1.4.1219.3"
         }
       ]
     }
@@ -56,7 +56,7 @@ For ValueSets to be properly used by CQL in the context of FHIR, the correspondi
 }
 ```
 
-NOTE: CRD will replace `<server-path>` with the base path of the CRD FHIR endpoint.
+NOTE: CRD will replace `<server-path>` with the base path of the CRD FHIR endpoint. This is used for ValueSets that are provided locally with the rule set. VSAC ValueSets should use the canonical URL.
 
 The resource type that each ValueSet will be used to filter on is referenced here. This should be used to indicate to the SMART applications or the FHIR server the scope of which resources are required for execution.
 


### PR DESCRIPTION
Now asks CRD for an expansion of the ValueSet using the `ValueSet/$expand` operator. Adds documentation for how to use ValueSets in rules.