### PR TITLE
DMEERX-754 and DMEERX-763 CQL Library Error checking and ValueSet error reporting

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -97,13 +97,18 @@ class App extends Component {
                 // look at main library elms to determine dependent elms to include
                 elmDependencies: mainLibraryElm.library.includes.def.map(
                   includeStatement => {
-                    return artifacts.dependentElms.find(elm => {
+                    let foundLibrary = artifacts.dependentElms.find(elm => {
                       return (
                         elm.library.identifier.id == includeStatement.path &&
                         elm.library.identifier.version ==
                           includeStatement.version
                       );
                     });
+                    if (foundLibrary != null) {
+                      return foundLibrary;
+                    } else {
+                      this.consoleLog(`Could not find library ${includeStatement.path}. Check if it is referenced in FHIR Library (${mainLibraryElm.library.identifier.id}) properly.`, `errorClass`)
+                    }
                   }
                 ),
                 valueSetDB: {},
@@ -222,12 +227,10 @@ class App extends Component {
               };
             });
           } else {
-            console.error(
-              `Valueset ${valueSet.id} does not have an expansion.`
-            );
+            this.consoleLog(`Valueset ${valueSet.id} does not have an expansion.`, 'errorClass');
           }
         } else {
-          console.error(`Could not find valueset ${valueSetDef.id}.`);
+          this.consoleLog(`Could not find valueset ${valueSetDef.id}. Try reloading with VSAC credentials in CRD.`, 'errorClass');
         }
       });
     });

--- a/src/util/fetchArtifacts.js
+++ b/src/util/fetchArtifacts.js
@@ -113,7 +113,15 @@ function fetchArtifacts(fhirPrefix, filePrefix, questionnaireReference, fhirVers
     function fetchValueSet(valueSetUrl) {
       pendingFetches += 1;
       consoleLog("about to fetchValueSet:", valueSetUrl);
-      fetch(valueSetUrl).then(handleFetchErrors).then(r => r.json())
+      fetch(valueSetUrl).then((response) => {
+        if (!response.ok) {
+          let msg = "Failure when fetching ValueSet " + valueSetUrl + " Make sure CRD has ValueSets Loaded.";
+          let details = `${msg}: ${response.url}: the server responded with a status of ${response.status} (${response.statusText})`;
+          consoleLog(msg, "errorClass", details);
+          reject(msg);
+        }
+        return response;
+      }).then(r => r.json())
       .then(valueSet => {
         pendingFetches -= 1;
         fetchedUrls.add(valueSetUrl);
@@ -135,7 +143,7 @@ function fetchArtifacts(fhirPrefix, filePrefix, questionnaireReference, fhirVers
       fetch(elmUrl).then(handleFetchErrors).then(r => r.json())
       .then(elm => {
         if ( elm.library.annotation ) {
-          let errors = elm.library.annotation.filter(a => a.errorSeverity != "warning");
+          let errors = elm.library.annotation.filter(a => a.type == "CqlToElmError" && a.errorSeverity != "warning");
           if (errors.length > 0) {
             let msg = "CQL to ELM translation resulted in errors.";
             let details = { "ELM annotation": elm.library.annotation };


### PR DESCRIPTION
Fixed CQL library checking that assumed every cql-to-elm 1.4.9 output was errored.
Added better error messages for CQL Library references if they failed to load.
Added better error messages for ValueSet loading.

Test with CRD branch `library-translation-support` and CDS_Library `Shared_CQL_Library`.