### PR TITLE
DMEERX-851 DTR Make use of dataRequirements for determining data to load

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -10,9 +10,7 @@ import PriorAuth from "./components/PriorAuth/PriorAuth";
 import QuestionnaireForm from "./components/QuestionnaireForm/QuestionnaireForm";
 import Testing from "./components/ConsoleBox/Testing";
 import UserMessage from "./components/UserMessage/UserMessage";
-import {createTask} from "./util/taskCreation";
 import TaskPopup from "./components/Popup/TaskPopup";
-import TextField from '@material-ui/core/TextField';
 
 // uncomment for testing UserMessage
 // let sampleError = {
@@ -122,7 +120,7 @@ class App extends Component {
                 ),
                 valueSetDB: {},
                 parameters: parameterObj,
-                neededResources: artifacts.neededResources
+                mainLibraryMaps: artifacts.mainLibraryMaps
               };
 
               // add the required value sets to the valueSetDB

--- a/src/App.js
+++ b/src/App.js
@@ -121,7 +121,8 @@ class App extends Component {
                   }
                 ),
                 valueSetDB: {},
-                parameters: parameterObj
+                parameters: parameterObj,
+                neededResources: artifacts.neededResources
               };
 
               // add the required value sets to the valueSetDB

--- a/src/elmExecutor/buildPopulatedResourceBundle.js
+++ b/src/elmExecutor/buildPopulatedResourceBundle.js
@@ -3,6 +3,7 @@ function doSearch(smart, type, fhirVersion, request, callback) {
   const q = {};
   let usePatient = true;
   // setup the query for Practitioner and Coverage
+  // TODO - handle other resource not associated with Patient? 
   switch (type) {
     case "Practitioner":
       let performer;

--- a/src/elmExecutor/executeElm.js
+++ b/src/elmExecutor/executeElm.js
@@ -72,7 +72,7 @@ function getPatientSource(fhirVersion) {
 
 // A list of FHIR resources can not be queried based on patient
 // TODO - reconsider how to handle them when implementing codeFilter
-const toRemoveList = ["Medication", "Organization"];
+const toRemoveList = ["Organization"];
 
 function retrieveNeededResource(libraryResource) {
   if (libraryResource.dataRequirement == null) return;

--- a/src/elmExecutor/executeElm.js
+++ b/src/elmExecutor/executeElm.js
@@ -8,7 +8,7 @@ function executeElm(smart, fhirVersion, request, executionInputs, consoleLog) {
   return new Promise(function(resolve, reject){
     console.log("about to executeElm()");
     const patientSource = getPatientSource(fhirVersion);
-    const neededResourcesFromLibrary = retrieveNeededResource(executionInputs.mainLibraryMaps[executionInputs.elm.library.identifier.id]);
+    const neededResourcesFromLibrary = retrieveNeededResources(executionInputs.mainLibraryMaps[executionInputs.elm.library.identifier.id]);
     //compareElmAndLibraryOutput(executionInputs, neededResourcesFromLibrary);
     consoleLog("need to fetch resources","infoClass");
     console.log("We need to fetch these resources:", neededResourcesFromLibrary);
@@ -74,7 +74,7 @@ function getPatientSource(fhirVersion) {
 // TODO - reconsider how to handle them when implementing codeFilter
 const toRemoveList = ["Organization"];
 
-function retrieveNeededResource(libraryResource) {
+function retrieveNeededResources(libraryResource) {
   if (libraryResource.dataRequirement == null) return;
   
   const requirementTypes = libraryResource.dataRequirement.map(

--- a/src/elmExecutor/executeElm.js
+++ b/src/elmExecutor/executeElm.js
@@ -8,7 +8,7 @@ function executeElm(smart, fhirVersion, request, executionInputs, consoleLog) {
   return new Promise(function(resolve, reject){
     console.log("about to executeElm()");
     const patientSource = getPatientSource(fhirVersion);
-    const neededResources = extractFhirResourcesThatNeedFetching(executionInputs.elm);
+    const neededResources = executionInputs.neededResources;
     consoleLog("need to fetch resources","infoClass");
     console.log("We need to fetch these resources:", neededResources);
     buildPopulatedResourceBundle(smart, neededResources, fhirVersion, request, consoleLog)

--- a/src/elmExecutor/executeElm.js
+++ b/src/elmExecutor/executeElm.js
@@ -8,10 +8,15 @@ function executeElm(smart, fhirVersion, request, executionInputs, consoleLog) {
   return new Promise(function(resolve, reject){
     console.log("about to executeElm()");
     const patientSource = getPatientSource(fhirVersion);
-    const neededResources = executionInputs.neededResources;
+    const neededResourcesFromElm = extractFhirResourcesThatNeedFetching(executionInputs.elm);
+    const neededResourcesFromLibrary = retrieveNeededResource(executionInputs.mainLibraryMaps[executionInputs.elm.library.identifier.id]);
+    console.log('--- executeElm library: ', executionInputs.elm.library.identifier.id);
+    console.log('******* neededResourceFromLibrary', neededResourcesFromLibrary);
+    console.log('---- ResourceByElm:', neededResourcesFromElm);
+    findDifference(neededResourcesFromElm, neededResourcesFromLibrary);
     consoleLog("need to fetch resources","infoClass");
-    console.log("We need to fetch these resources:", neededResources);
-    buildPopulatedResourceBundle(smart, neededResources, fhirVersion, request, consoleLog)
+    console.log("We need to fetch these resources:", neededResourcesFromLibrary);
+    buildPopulatedResourceBundle(smart, neededResourcesFromLibrary, fhirVersion, request, consoleLog)
     .then(function(resourceBundle) {
       console.log("Fetched resources are in this bundle:", resourceBundle);
       patientSource.loadBundles([resourceBundle]);
@@ -27,6 +32,22 @@ function executeElm(smart, fhirVersion, request, executionInputs, consoleLog) {
   });
 }
 
+function findDifference(array1, array2) {
+  let temp = [];
+  for (var i = 0; i < array1.length; i++) {
+    if (!array2.includes(array1[i])) {
+      temp.push(array1[i])
+    } 
+  }
+
+  for(var i = 0; i < array2.length; i++) {
+    if (!array1.includes(array2[i])) {
+      temp.push(array2[i])
+    }
+  }
+
+  console.log('--- NeededResources Difference: ', temp);
+}
 function executeElmAgainstPatientSource(executionInputs, patientSource) {
   // executionInputs.elmDependencies = [ fhirhelpersElm ]
   const repository = new cql.Repository(executionInputs.elmDependencies);
@@ -41,6 +62,24 @@ function getPatientSource(fhirVersion) {
   if (fhirVersion == "dstu2") return cqlfhir.PatientSource.FHIRv102();
   if (fhirVersion == "stu3") return cqlfhir.PatientSource.FHIRv300();
   if (fhirVersion == "r4") return cqlfhir.PatientSource.FHIRv400();
+}
+
+// A list of FHIR resources can not be queried based on patient
+// TODO - reconsider how to handle when implementing codeFilter
+const toRemoveList = ["Medication", "Organization"];
+
+function retrieveNeededResource(libraryResource) {
+  if (libraryResource.dataRequirement == null) return;
+  console.log("--retrieving NeededResource from library:", libraryResource.name);
+
+  const requirementTypes = libraryResource.dataRequirement.map(
+    (d) => d.type
+  );
+  let neededResources = new Set();
+  requirementTypes.forEach(type => neededResources.add(type));
+ 
+  console.log("-- retrieved neededResource:", neededResources);
+  return Array.from(neededResources).filter(item => !toRemoveList.includes(item));
 }
 
 


### PR DESCRIPTION
This PR changes DTR to decide on what FHIR resources of a patient to load to pass to CQL engine by using dataRequirements of the Library. 
Right now, for the existing DRLS CMS rules and from example rule (Mettle Solutions), we have three types of dataRequirements:
1. FHIR resources can be queried by the patient context: this will be loaded by DTR
2. FHIR resources can not be queried by the patient context: this will not be loaded by DTR as DTR queries only, e.g. Organization (in Mettle Solution rule set)
3. ValueSet: since the only purpose of such kind of dataRequirements is to load the ValueSet from VSAC, DTR will not load the FHIR resource from EHR. Those dataRequirements are specified in "type" as ResourcenameValueSet, e.g. MedicationValueSet, DeviceRequestValueSet. 

To test the PR, use CDS-Library branch "datareq", test each of the topics to verify the prepopulation still works as before. 

Note: For Mettle Solutions' rule set, the population still doesn't work yet as it depends on https://jira.mitre.org/browse/DMEERX-862 