### PR TITLE
extract codes from compose valueset

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -238,8 +238,29 @@ class App extends Component {
                 version: code.version
               };
             });
-          } else {
-            this.consoleLog(`Valueset ${valueSet.id} does not have an expansion.`, 'errorClass');
+          } else if (valueSet.compose != null) {
+           this.consoleLog(`Valueset ${valueSet.id} has a compose.`, 'infoClass');
+            
+            var codeList = valueSet.compose.include.map(code => {
+              if (code.filter != null) {
+                this.consoleLog(`code ${code} has a filter and is not supported.`, 'infoClass');
+              }
+              var conceptList = code.filter == null ? code.concept : [];
+              var system = code.system;
+              var codeList = [];
+              conceptList.forEach(concept => {
+                codeList.push( {
+                  code: concept.code,
+                  system: system,
+                  version: concept.version
+                });
+              });
+              return codeList;
+            });
+            executionInputs.valueSetDB[valueSetDef.id] = {};
+            executionInputs.valueSetDB[valueSetDef.id][
+              ""
+            ] = codeList.length > 0 ? codeList[0] : null;
           }
         } else {
           this.consoleLog(`Could not find valueset ${valueSetDef.id}. Try reloading with VSAC credentials in CRD.`, 'errorClass');


### PR DESCRIPTION
This PR extracts codes from extensional compose value sets. 
To verify that the code works, it probably needs the help from the browser debug tool. 

Mettle solution rule sets has a compose value set and it is located in https://github.com/HL7-DaVinci/CDS-Library/blob/master/Examples/Shared/R4/resources/ValueSet-R4-Cardio_Exam.json
It is defined in this CQL file: 
https://github.com/HL7-DaVinci/CDS-Library/blob/master/Examples/LowerLimbProsthesis/R4/files/LowerLimbProsthesis-1.0.0.cql#L19
It is used here:  https://github.com/HL7-DaVinci/CDS-Library/blob/master/Examples/LowerLimbProsthesis/R4/files/LowerLimbProsthesis-1.0.0.cql#L294

You can verify the codes are extracted from this value set by using the debugger.
See the screen shots below:

- The elmResult of CardioPulmonary has a procedure:

![Screen Shot 2021-04-29 at 10 18 47 AM](https://user-images.githubusercontent.com/58572522/116566178-88684500-a8d4-11eb-8a8c-15a3234aafe9.png)

- The valueset in executionInputs contains the actual codes:

![Screen Shot 2021-04-29 at 10 19 28 AM](https://user-images.githubusercontent.com/58572522/116566400-bbaad400-a8d4-11eb-9ce7-d29b6b30ee65.png)
 