### PR TITLE
proxy post request with library

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -3,8 +3,7 @@
 /**
  * Module dependencies.
  */
-const request = require("request");
-const app = require("../src/backend/app");
+const startApp = require("../src/backend/app");
 const http = require("http");
 const debug = require("debug")("dtr:backend");
 
@@ -12,6 +11,7 @@ const debug = require("debug")("dtr:backend");
  * Get port from environment and store in Express.
  */
 function startServer(serverPort, serverHttpy, serverHost, serverPublic, proxyTarget) {
+    const app = startApp(proxyTarget);
     const port = normalizePort(process.env.PORT || serverPort);
     app.set("port", port);
 
@@ -30,29 +30,11 @@ function startServer(serverPort, serverHttpy, serverHost, serverPublic, proxyTar
     server.on("listening", onListening);
 
 
-    app.use("/fhir", function (req, res) {
-        var url = proxyTarget + "/fhir" + req.url;
-        console.log(url);
 
-        req.pipe(request({
-            url: url, agentOptions: {
-                rejectUnauthorized: false
-            }
-        })).pipe(res);
-    });
-    app.use("/files", function (req, res) {
-        var url = proxyTarget + "/files" + req.url;
-        console.log(url);
-
-        req.pipe(request({
-            url: url, agentOptions: {
-                rejectUnauthorized: false
-            }
-        })).pipe(res);
-    });
 
 
     app.use((req, res, next) => {
+        console.log(req.method);
         if (req.method === "POST") {
             req.body.createdAt = Date.now();
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "es6-promise": "^4.2.6",
         "express": "^4.17.1",
         "fhirclient": "2.1.0",
+        "http-proxy-middleware": "^0.18.0",
         "isomorphic-fetch": "^2.2.1",
         "lodash": "^4.17.21",
         "lowdb": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "es6-promise": "^4.2.6",
     "express": "^4.17.1",
     "fhirclient": "2.1.0",
+    "http-proxy-middleware": "^0.18.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.21",
     "lowdb": "^1.0.0",

--- a/src/backend/app.js
+++ b/src/backend/app.js
@@ -1,25 +1,39 @@
 const express = require("express");
 const dbRouter = require("./routes/database");
 const bodyParser = require("body-parser");
+const request = require("request");
+const createProxyMiddleware = require("http-proxy-middleware");
 
-const app = express();
+function startApp(proxyTarget) {
+    const app = express();
+    app.use("/fhir", createProxyMiddleware({ target: proxyTarget, changeOrigin: false }));
+    app.use("/files", function (req, res) {
+        var url = proxyTarget + "/files" + req.url;
+        req.pipe(request({
+            url: url, agentOptions: {
+                rejectUnauthorized: false
+            }
+        })).pipe(res);
+    });
+    app.use(express.json());
+    app.use(bodyParser.json({ type: ["application/json", "application/fhir+json"] }));
+    app.use(express.static(`${__dirname}/../../public/`));
+    app.get("/register", function(req, res){
+        res.sendFile("register.html", {root: "./public"});
+    });
+    app.get("/index", function(req, res){
+        res.sendFile("index.html", {root: "./public"});
+    });
+    app.get("/launch", function(req, res){
+        res.sendFile("launch.html", {root: "./public"});
+    });
+    app.get("/logs", function(req, res){
+        res.sendFile("logs.html", {root: "./public"});
+    });
 
-app.use(express.json());
-app.use(bodyParser.json({ type: ["application/json", "application/fhir+json"] }));
-app.use(express.static(`${__dirname}/../../public/`));
-app.get("/register", function(req, res){
-    res.sendFile("register.html", {root: "./public"});
-});
-app.get("/index", function(req, res){
-    res.sendFile("index.html", {root: "./public"});
-});
-app.get("/launch", function(req, res){
-    res.sendFile("launch.html", {root: "./public"});
-});
-app.get("/logs", function(req, res){
-    res.sendFile("logs.html", {root: "./public"});
-});
+    app.use("/", dbRouter);
+    console.log("starting backend");
+    return app;
+}
 
-app.use("/", dbRouter);
-console.log("starting backend");
-module.exports = app;
+module.exports = startApp;

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ console.log(standalone);
 updateLog(log);
 // This endpoint available when deployed in CRD server, for development we have
 // the proxy set up in webpack.config.dev.js so the CRD server needs to be running
-const FHIR_PREFIX = "../../fhir/";
+const FHIR_PREFIX = "/fhir/";
 const FILE_PREFIX = "../../"
 var data = `code=${code}&grant_type=authorization_code&redirect_uri=${redirectUri}`;
 // const data = new URLSearchParams();


### PR DESCRIPTION
This fixes the bug where sending the QuestionnaireResponse to the payer causes a `400 bad request` error.   The actual `400` was occurring because the body parser of the express app was emptying the body of the request before it got to the proxy, so the actual request being sent to the CRD server would have an empty body.  This is fixed by moving the bodyparser after the proxy endpoint.

Then there was another extra problem where `POST` requests were getting a `403 forbidden` error.  The issue was that when we swapped from proxying requests with webpack to piping the request directly using express on the backend, the GET requests were fine but making a POST request was blocked.  I used a proxy library to fix the problem.