### PR TITLE
include patient id with questionnaire response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1933,6 +1933,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -71,6 +71,7 @@ class App extends Component {
   }
 
   standaloneLaunch(patient, response) {
+      this.patientId = patient;
       const template = `Questionnaire/${response.questionnaire}`;
       fetchFhirVersion(this.props.smart.state.serverUrl)
       .then(fhirVersion => {

--- a/src/components/PatientSelect/PatientBox.jsx
+++ b/src/components/PatientSelect/PatientBox.jsx
@@ -119,7 +119,7 @@ export default class PatientBox extends Component {
                 value={this.state.responseId}
                 onChange={this.handleChange}
                 >
-                {this.props.responses.map((response) =>{
+                {this.props.responses.reverse().map((response) =>{
                     return <MenuItem key={response.id} value={response.id}>{`${response.questionnaire} - ${new Date(response.authored).toDateString()}`}</MenuItem>
                 })}
                 </Select>

--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -698,10 +698,13 @@ export default class QuestionnaireForm extends Component {
     var qr = window.LForms.Util.getFormFHIRData('QuestionnaireResponse', 'R4', "#formContainer");
     console.log(qr);
     qr.status = status;
-    qr.author = {
-      reference:
-        this.getPractitioner()
-    };
+    if (this.getPractitioner() !== "Unknown") {
+        // logica ehr doesn't like "unknown"
+        qr.author = {
+            reference:
+              this.getPractitioner()
+          };
+    }
     this.getPatient();
     qr.subject = {
       reference:
@@ -712,7 +715,6 @@ export default class QuestionnaireForm extends Component {
 
     console.log(this.props.attested);
     const aa = searchQuestionnaire(qr, this.props.attested);
-    console.log(aa);
     return qr;
   }
 


### PR DESCRIPTION
fixes saving the questionnaire response on logica health.  The 400 error was due to a the "unknown" patient and practitioner ID.  Goes along with the fix to POST requests after switching the proxy.

