### PR TITLE
add eval map

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ module.exports = {
         publicPath: "/"
       },
 	watch: true,
+    devtool: "#eval-source-map",
     resolve: { extensions: ["*", ".js", ".jsx"] },
 	module: {
 		rules: [

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,3 +1,4 @@
 const config = require("./webpack.config");
 config.watch = false;
+config.devtool = false;
 module.exports = config;


### PR DESCRIPTION
adds source map to webpack.  It will take a little longer to build, but you should be able to see what file/line logs and errors come from.