### PR TITLE
Refresh EHR data when loading saved questionnaire

### DIFF
--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -1055,61 +1055,36 @@ export default class QuestionnaireForm extends Component {
 
   updateSavedResponseWithPrepopulation = (newOne, saved) => {
     newOne.item.map(newItem => {
-        let savedIndex = saved.item.findIndex(savedItem => newItem.linkId == savedItem.linkId);
-        if(savedIndex != -1) {
-            updateItem(newItem, saved.item[savedIndex]);
-        }
+      let savedIndex = saved.item.findIndex(savedItem => newItem.linkId == savedItem.linkId);
+      if (savedIndex != -1) {
+        updateItem(newItem, saved.item[savedIndex]);
+      }
     })
 
     function updateItem(newItem, savedItem) {
-        if(newItem.item == undefined) {
-            //find the corresponding linkId in savedItem and replace it
-            function replaceItem (savedItem) {
-                if(savedItem.item == undefined) {
-                    console.log("Couldn't found linkId in the savedItem");
-                    return;
-                }
-                let foundSavedItemIndex = savedItem.item.findIndex(saved => saved.linkId == newItem.linkId);
-                if(foundSavedItemIndex != -1) {
-                    savedItem.item[foundSavedItemIndex] = newItem;
-                    return;
-                } else {
-                    replaceItem(savedItem.item);
-                }
-            };
-            replaceItem(savedItem);
-        } else {
-            newItem.item.forEach(newSubItem => {
-                updateItem(newSubItem, savedItem);
-            });
-        }
+      if (newItem.item == undefined) {
+        //find the corresponding linkId in savedItem and replace it
+        function replaceItem(savedItem) {
+          if (savedItem.item == undefined) {
+            // Couldn't found linkId in the savedItem, ignore it
+            return;
+          }
+          let foundSavedItemIndex = savedItem.item.findIndex(saved => saved.linkId == newItem.linkId);
+          if (foundSavedItemIndex != -1) {
+            savedItem.item[foundSavedItemIndex] = newItem;
+            return;
+          } else {
+            replaceItem(savedItem.item);
+          }
+        };
+        replaceItem(savedItem);
+      } else {
+        newItem.item.forEach(newSubItem => {
+          updateItem(newSubItem, savedItem);
+        });
+      }
     }
   };
-
-  mergeSavedResponseFromPrepopulation(newResponse, partialResponse) {
-    newResponse.item.forEach(newRootItem => {
-      let index = partialResponse.item.findIndex(savedItem => newRootItem.linkId == savedItem.linkId);
-      if (index != -1) {
-        let foundSavedItem = partialResponse.item[index];
-        //replace the items with new response item
-        if (foundSavedItem.item != undefined) {
-          if (newRootItem.item != undefined) {
-            newRootItem.item.forEach(newSubItem => {
-              let subItemIndex = foundSavedItem.item.findIndex(savedSubItem => newSubItem.linkId == savedSubItem.linkId);
-              if (subItemIndex != -1) {
-                foundSavedItem.item[subItemIndex] = newSubItem;
-              }
-            })
-          }
-        }
-        else {
-          partialResponse.item[index] = foundSavedItem;
-        }
-      }
-    });
-
-    console.log("Merged response ", partialResponse);
-  }
 
   popupClear(title, finalOption, logTitle) {
     this.setState({

--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -39,7 +39,7 @@ export default class QuestionnaireForm extends Component {
     this.getLibraryPrepopulationResult = this.getLibraryPrepopulationResult.bind(this);
     this.buildGTableItems = this.buildGTableItems.bind(this);
     this.mergeResponseForSameLinkId = this.mergeResponseForSameLinkId.bind(this);
-    this.updateMergeItem = this.updateMergeItem.bind(this);
+    //this.updateMergeItem = this.updateMergeItem.bind(this);
     this.updateSavedResponseWithPrepopulation = this.updateSavedResponseWithPrepopulation.bind(this);
 
     DTRQuestionnaireResponseURL += this.fhirVersion.toLowerCase();
@@ -1054,7 +1054,7 @@ export default class QuestionnaireForm extends Component {
     }
   }
 
-  updateMergeItem (newItem, savedItem, parentLinkId) {
+  /*updateMergeItem (newItem, savedItem, parentLinkId) {
     if (newItem.item == undefined) {
       //find the corresponding linkId in savedItem and replace it
       function replaceItem(savedItem) {
@@ -1070,24 +1070,14 @@ export default class QuestionnaireForm extends Component {
             }
           }
         };
-        //find the parent linkId
-        //const parentLinkId = newItem.linkId.slice(0, newItem.linkId.lastIndexOf("."));
+      
         const savedParentItem = findSavedParentItem(parentLinkId, savedItem);
-
         const replaceOrInsertItem = (newResponseItem, savedParentItem) => {
           const replaceIndex = savedParentItem.item.findIndex(item => item.linkId == newResponseItem.linkId);
           if (replaceIndex != -1) {
             savedParentItem.item[replaceIndex] = newResponseItem;
           } else {
             savedParentItem.item.push(newResponseItem);
-           /* savedParentItem.item.sort((firstItem, secondItem) => {
-              const getItemNumber = item => Number.parseInt(item.linkId.slice(item.linkId.lastIndexOf(".") + 1));
-              if (getItemNumber(firstItem) < getItemNumber(secondItem)) {
-                return -1;
-              } else {
-                return 1;
-              }
-            }); */
           }
         };
         if (savedParentItem != undefined) {
@@ -1101,15 +1091,54 @@ export default class QuestionnaireForm extends Component {
         this.updateMergeItem(newSubItem, savedItem, newItem.linkId);
       });
     }
-  };
+  }; */
 
   updateSavedResponseWithPrepopulation = (newOne, saved) => {
+    const updateMergeItem  = (newItem, savedItem, parentLinkId)  => {
+      if (newItem.item == undefined) {
+        //find the corresponding linkId in savedItem and replace it
+        function replaceItem(savedItem) {
+          const findSavedParentItem = (parentLinkId, savedItem) => {
+            if (savedItem.linkId == parentLinkId) {
+              return savedItem;
+            } else {
+              const parentIndex = savedItem.item.findIndex(item => item.linkId == parentLinkId);
+              if (parentIndex != -1) {
+                return savedItem.item[parentIndex];
+              } else {
+                findSavedParentItem(parentLinkId, savedItem.item);
+              }
+            }
+          };
+        
+          const savedParentItem = findSavedParentItem(parentLinkId, savedItem);
+          const replaceOrInsertItem = (newResponseItem, savedParentItem) => {
+            const replaceIndex = savedParentItem.item.findIndex(item => item.linkId == newResponseItem.linkId);
+            if (replaceIndex != -1) {
+              savedParentItem.item[replaceIndex] = newResponseItem;
+            } else {
+              savedParentItem.item.push(newResponseItem);
+            }
+          };
+          if (savedParentItem != undefined) {
+            replaceOrInsertItem(newItem, savedParentItem);
+          }
+        };
+  
+        replaceItem(savedItem);
+      } else {
+        newItem.item.forEach(newSubItem => {
+          updateMergeItem(newSubItem, savedItem, newItem.linkId);
+        });
+      }
+    };
+
     newOne.item.map(newItem => {
       let savedIndex = saved.item.findIndex(savedItem => newItem.linkId == savedItem.linkId);
       if (savedIndex != -1) {
-        this.updateMergeItem(newItem, saved.item[savedIndex]);
+        updateMergeItem(newItem, saved.item[savedIndex], newOne.linkId);
       }
-    })
+    });
   };
 
   popupClear(title, finalOption, logTitle) {

--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -1082,8 +1082,6 @@ export default class QuestionnaireForm extends Component {
             savedParentItem.item.push(newResponseItem);
             savedParentItem.item.sort((firstItem, secondItem) => {
               const getItemNumber = item => Number.parseInt(item.linkId.slice(item.linkId.lastIndexOf(".") + 1));
-              console.log(getItemNumber(firstItem));
-              console.log(getItemNumber(secondItem));
               if (getItemNumber(firstItem) < getItemNumber(secondItem)) {
                 return -1;
               } else {

--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -1054,7 +1054,7 @@ export default class QuestionnaireForm extends Component {
     }
   }
 
-  updateMergeItem (newItem, savedItem) {
+  updateMergeItem (newItem, savedItem, parentLinkId) {
     if (newItem.item == undefined) {
       //find the corresponding linkId in savedItem and replace it
       function replaceItem(savedItem) {
@@ -1071,7 +1071,7 @@ export default class QuestionnaireForm extends Component {
           }
         };
         //find the parent linkId
-        const parentLinkId = newItem.linkId.slice(0, newItem.linkId.lastIndexOf("."));
+        //const parentLinkId = newItem.linkId.slice(0, newItem.linkId.lastIndexOf("."));
         const savedParentItem = findSavedParentItem(parentLinkId, savedItem);
 
         const replaceOrInsertItem = (newResponseItem, savedParentItem) => {
@@ -1080,14 +1080,14 @@ export default class QuestionnaireForm extends Component {
             savedParentItem.item[replaceIndex] = newResponseItem;
           } else {
             savedParentItem.item.push(newResponseItem);
-            savedParentItem.item.sort((firstItem, secondItem) => {
+           /* savedParentItem.item.sort((firstItem, secondItem) => {
               const getItemNumber = item => Number.parseInt(item.linkId.slice(item.linkId.lastIndexOf(".") + 1));
               if (getItemNumber(firstItem) < getItemNumber(secondItem)) {
                 return -1;
               } else {
                 return 1;
               }
-            });
+            }); */
           }
         };
         if (savedParentItem != undefined) {
@@ -1098,7 +1098,7 @@ export default class QuestionnaireForm extends Component {
       replaceItem(savedItem);
     } else {
       newItem.item.forEach(newSubItem => {
-        this.updateMergeItem(newSubItem, savedItem);
+        this.updateMergeItem(newSubItem, savedItem, newItem.linkId);
       });
     }
   };

--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -39,7 +39,6 @@ export default class QuestionnaireForm extends Component {
     this.getLibraryPrepopulationResult = this.getLibraryPrepopulationResult.bind(this);
     this.buildGTableItems = this.buildGTableItems.bind(this);
     this.mergeResponseForSameLinkId = this.mergeResponseForSameLinkId.bind(this);
-    //this.updateMergeItem = this.updateMergeItem.bind(this);
     this.updateSavedResponseWithPrepopulation = this.updateSavedResponseWithPrepopulation.bind(this);
 
     DTRQuestionnaireResponseURL += this.fhirVersion.toLowerCase();
@@ -1054,10 +1053,11 @@ export default class QuestionnaireForm extends Component {
     }
   }
 
-  /*updateMergeItem (newItem, savedItem, parentLinkId) {
-    if (newItem.item == undefined) {
-      //find the corresponding linkId in savedItem and replace it
-      function replaceItem(savedItem) {
+
+  updateSavedResponseWithPrepopulation = (newOne, saved) => {
+    const updateMergeItem = (newItem, savedItem, parentLinkId) => {
+      if (newItem.item == undefined) {
+        //find the corresponding linkId in savedItem and replace it
         const findSavedParentItem = (parentLinkId, savedItem) => {
           if (savedItem.linkId == parentLinkId) {
             return savedItem;
@@ -1070,7 +1070,7 @@ export default class QuestionnaireForm extends Component {
             }
           }
         };
-      
+
         const savedParentItem = findSavedParentItem(parentLinkId, savedItem);
         const replaceOrInsertItem = (newResponseItem, savedParentItem) => {
           const replaceIndex = savedParentItem.item.findIndex(item => item.linkId == newResponseItem.linkId);
@@ -1083,49 +1083,6 @@ export default class QuestionnaireForm extends Component {
         if (savedParentItem != undefined) {
           replaceOrInsertItem(newItem, savedParentItem);
         }
-      };
-
-      replaceItem(savedItem);
-    } else {
-      newItem.item.forEach(newSubItem => {
-        this.updateMergeItem(newSubItem, savedItem, newItem.linkId);
-      });
-    }
-  }; */
-
-  updateSavedResponseWithPrepopulation = (newOne, saved) => {
-    const updateMergeItem  = (newItem, savedItem, parentLinkId)  => {
-      if (newItem.item == undefined) {
-        //find the corresponding linkId in savedItem and replace it
-        function replaceItem(savedItem) {
-          const findSavedParentItem = (parentLinkId, savedItem) => {
-            if (savedItem.linkId == parentLinkId) {
-              return savedItem;
-            } else {
-              const parentIndex = savedItem.item.findIndex(item => item.linkId == parentLinkId);
-              if (parentIndex != -1) {
-                return savedItem.item[parentIndex];
-              } else {
-                findSavedParentItem(parentLinkId, savedItem.item);
-              }
-            }
-          };
-        
-          const savedParentItem = findSavedParentItem(parentLinkId, savedItem);
-          const replaceOrInsertItem = (newResponseItem, savedParentItem) => {
-            const replaceIndex = savedParentItem.item.findIndex(item => item.linkId == newResponseItem.linkId);
-            if (replaceIndex != -1) {
-              savedParentItem.item[replaceIndex] = newResponseItem;
-            } else {
-              savedParentItem.item.push(newResponseItem);
-            }
-          };
-          if (savedParentItem != undefined) {
-            replaceOrInsertItem(newItem, savedParentItem);
-          }
-        };
-  
-        replaceItem(savedItem);
       } else {
         newItem.item.forEach(newSubItem => {
           updateMergeItem(newSubItem, savedItem, newItem.linkId);


### PR DESCRIPTION
This PR reloads EHR data when loading saved questionnaires. 

To test:
1. Open a questionnaire, e.g. I use the lab form of RAD of pat014 Theodor Roosevelt
2. Right now, you can modify some pre-populated value, e.g. for the above patient, PaO2, change it to a different value; also fill in some other fields which are not pre-populated, then save the form
3. Reopen the lab form, pick the saved form from step 2
4. When the form is opened, PaO2's value should be overwritten and is displayed as the value stored in EHR; the values in the those fields which are not pre-populated should be retained as before