### PR TITLE
fix filter issues

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -353,10 +353,9 @@ export default class App extends Component {
         this.setAttested(icon, linkId);
     };
   }
-  setTasks() { 
+  setTasks() {
       if(!this.state.tasks) {
         const questions = Array.from(document.querySelectorAll(`[ng-click="setActiveRow(item)"]:not(.lf-section-header)`));
-
             questions.map((q)=>{
                 var node = document.createElement("div");
                 node.className = "task-input draft"
@@ -446,7 +445,7 @@ export default class App extends Component {
       sections.map((element) => {
         if(!element.querySelector(".ng-empty")) {
             const nonEmpty = Array.from(element.querySelectorAll(".ng-not-empty"))
-            const actuallyNotEmpty = true;
+            let actuallyNotEmpty = true;
             // check multi-choice questions to make sure
             // they actually have an answer before we 
             // filter out the entire section
@@ -478,6 +477,9 @@ export default class App extends Component {
                     const ul = e.parentElement.querySelector("ul");
                     if (ul && !ul.querySelector("li")) {
                         // the multi-choice question doesn't have an answer
+                        doFilter = false;
+                    } else if (!ul) {
+                        // this question is empty and isn't multi-choice
                         doFilter = false;
                     }
                 })


### PR DESCRIPTION
there were a couple bugs that these changes fix:

**Bug 1:**
The "Order Reason" in the home oxygen therapy questionnaire was filtered incorrectly, being filtered out even if it was not answered.  

**Reason:**
The Order Reason was actually being filtered because it has sub-items, which categorize it as a "section".  Since sections are filtered out based on whether all their sub-items are filled, Order Reason would be filtered out since its section technically doesn't have anything in it when it is unanswered.  

**Fix:** 
`!element.parentElement.querySelector(".ng-empty")` checks the parent element to ensure it's also not empty before it hides the entire section.  This is only applicable for questions that themselves have sub-items, not groups which is how most of the sections are defined.

**Bug 2:** 
The horizontal sections get filtered out if any of the boxes are filled out.  Unanswered questions in the row get filtered when they shouldn't be.

**Reason:**
The filter checks for items that are empty, and then finds the closest `.lf-table-item` to that item, which is the class given to that question's row.  If any of the items are answered, the filter will hide the entire row, since it only expects one question per `.lf-table-item`.

**Fix:**
`const totalQs = inputRowElement.querySelectorAll("td").length;`
`const filledQs = inputRowElement.querySelectorAll(".ng-not-empty:not([disabled]):not(.tooltipContent)").length;`

By comparing the total number of questions in the row with the number of answered questions, we can check if every question in the row is answered, and then filter the entire row only when all questions are answered.  Another option would be to actually filter each individual question but this would be pretty ugly and not really free up any space.

**Bug 3:**
The multi-choice questions are sometimes considered non-empty when they are, in fact, empty.

**Reason:**
The filter only considers the input box for multi-choice questions, not the answers, which unlike normal questions are put into an unordered list above the input box.  The input box considers itself not-empty even when there are no answers in the list.

**Fix:**
The multi-choice questions are treated as a special case and `inputRowElement.parentElement.querySelector("ul").querySelector("li")` checks to see if there are any answers in the list.  They are considered answered if there are any elements in the `ul`.