### PR TITLE
Fix non-selectable Previous Forms issue (DMEERX 1162)

### DIFF
--- a/src/components/QuestionnaireForm/QuestionnaireForm.jsx
+++ b/src/components/QuestionnaireForm/QuestionnaireForm.jsx
@@ -233,7 +233,7 @@ export default class QuestionnaireForm extends Component {
         const questionnaireId = bundleEntry.resource.contained[0].id;
         const questionaireIdUrl = bundleEntry.resource.questionnaire;
 
-        if (this.props.qform.id == questionnaireId || this.props.qform.id.contains(questionaireIdUrl)) {
+        if (this.props.qform.id === questionnaireId || this.props.qform.id.contains(questionaireIdUrl)) {
           count = count + 1;
           // add the option to the popupOptions
           let date = new Date(bundleEntry.resource.authored);


### PR DESCRIPTION
This PR fixes an issue where previously saved adaptive forms could not be selected. It would just always say "No forms to load".